### PR TITLE
chore(validation): Appropriately mark required request bodies

### DIFF
--- a/bapi/2024-10-01.yml
+++ b/bapi/2024-10-01.yml
@@ -199,7 +199,7 @@ paths:
       summary: Verify a client
       description: Verifies the client in the provided token
       requestBody:
-        description: Parameters.
+        required: true
         content:
           application/json:
             schema:
@@ -249,6 +249,7 @@ paths:
       summary: Create an email address
       description: Create a new email address
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -378,6 +379,7 @@ paths:
       summary: Create a phone number
       description: Create a new phone number
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -482,6 +484,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -1721,6 +1724,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -1897,6 +1901,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -1947,6 +1952,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2199,6 +2205,7 @@ paths:
       tags:
         - Invitations
       requestBody:
+        required: true
         description: Required parameters
         content:
           application/json:
@@ -2372,6 +2379,7 @@ paths:
       tags:
         - Allow-list / Block-list
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2442,6 +2450,7 @@ paths:
       tags:
         - Allow-list / Block-list
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2493,6 +2502,7 @@ paths:
       tags:
         - Beta Features
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2578,6 +2588,7 @@ paths:
       tags:
         - Actor Tokens
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2663,6 +2674,7 @@ paths:
       tags:
         - Domains
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2780,6 +2792,7 @@ paths:
       tags:
         - Instance Settings
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2840,6 +2853,7 @@ paths:
       tags:
         - Instance Settings
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2881,6 +2895,7 @@ paths:
       tags:
         - Beta Features
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2911,6 +2926,7 @@ paths:
       tags:
         - Instance Settings
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -3002,6 +3018,7 @@ paths:
       tags:
         - JWT Templates
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -3081,6 +3098,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -3215,6 +3233,7 @@ paths:
       tags:
         - Organizations
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -3429,6 +3448,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
@@ -4123,6 +4143,7 @@ paths:
       tags:
         - Proxy checks
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -4158,6 +4179,7 @@ paths:
       tags:
         - Redirect URLs
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -4222,6 +4244,7 @@ paths:
       tags:
         - Sign-in Tokens
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -4279,6 +4302,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -4328,6 +4352,7 @@ paths:
       tags:
         - OAuth Applications
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -4498,6 +4523,7 @@ paths:
       tags:
         - SAML Connections
       requestBody:
+        required: true
         content:
           application/json:
             schema:


### PR DESCRIPTION
Marks `requestBody`'s as required. They're false by default.