### PR TITLE
fix: Loosens `IdentificationLink` to string

### DIFF
--- a/bapi/2021-02-05.yml
+++ b/bapi/2021-02-05.yml
@@ -5430,10 +5430,6 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - oauth_google
-            - oauth_mock
-            - saml
         id:
           type: string
       required:

--- a/bapi/2024-10-01.yml
+++ b/bapi/2024-10-01.yml
@@ -5426,10 +5426,6 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - oauth_google
-            - oauth_mock
-            - saml
         id:
           type: string
       required:


### PR DESCRIPTION
Matches changes in BAPI