### PR TITLE
fix: Remove additional Org Memberships

### DIFF
--- a/bapi/2021-02-05.yml
+++ b/bapi/2021-02-05.yml
@@ -125,8 +125,6 @@ tags:
     description: Manage waitlist entries.
   - name: Proxy Checks
     description: Check if a user is using a proxy.
-  - name: Organization Memberships
-    description: Manage organization memberships.
   - name: Organization Domains
     description: Manage organization domains.
 externalDocs:

--- a/bapi/2024-10-01.yml
+++ b/bapi/2024-10-01.yml
@@ -125,8 +125,6 @@ tags:
     description: Manage waitlist entries.
   - name: Proxy Checks
     description: Check if a user is using a proxy.
-  - name: Organization Memberships
-    description: Manage organization memberships.
   - name: Organization Domains
     description: Manage organization domains.
 externalDocs:


### PR DESCRIPTION
For some reason the Cloud Build process isn't seeing the changes. Updating manually.