### PR TITLE
chore: revert adding the machineSecretKey security scheme

### DIFF
--- a/bapi/2025-04-10.yml
+++ b/bapi/2025-04-10.yml
@@ -27,7 +27,6 @@ servers:
   - url: https://api.clerk.com/v1
 security:
   - bearerAuth: []
-  - machineSecretKey: []
 tags:
   - name: Actor Tokens
     description: Allow your users to sign in on behalf of other users.
@@ -7429,11 +7428,6 @@ components:
       type: http
       scheme: bearer
       description: Internal management token.
-    machineSecretKey:
-      type: http
-      scheme: bearer
-      description: Machine secret key, obtained under "M2M authentication" in the Clerk Dashboard.
-      bearerFormat: ak_<secret value>
   schemas:
     JWKS.ed25519.PublicKey:
       type: object


### PR DESCRIPTION
This change reverts the newly added `machineSecretKey` security scheme to the `bapi` spec because it introduces a breaking change on SDK regeneration.