### PR TITLE
Add Github action to invalidate the clerk.com/fapi and clerk.com/bapi scalar cached specs

### DIFF
--- a/.github/workflows/invalidate-docs.yml
+++ b/.github/workflows/invalidate-docs.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   invalidate-docs:
+    permissions: none
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/invalidate-docs.yml
+++ b/.github/workflows/invalidate-docs.yml
@@ -1,0 +1,20 @@
+name: Invalidate Docs on Push to Main
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  invalidate-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Invalidate Documentation
+        run: |
+          curl --request POST \
+            --url https://clerk.com/docs/reference/spec/invalidate \
+            --header 'Content-Type: application/json' \
+            --header 'authorization: Bearer ${{ secrets.DOCS_REVALIDATE_SECRET }}' \
+            --data '{}'
+        env:
+          DOCS_REVALIDATE_SECRET: ${{ secrets.DOCS_REVALIDATE_SECRET }}


### PR DESCRIPTION
I recently added an endpoint to clerk.com that allows us to invalidate the cached copies of the specs that scalar uses in the api reference docs. https://github.com/clerk/clerk/pull/1525

This pr adds a workflow that calls this endpoint on pushes to main. I've also added a `DOCS_REVALIDATE_SECRET` environment variable to the secrets of this repo.