### PR TITLE
Fix permissions for invalidate-docs.yml

### DIFF
--- a/.github/workflows/invalidate-docs.yml
+++ b/.github/workflows/invalidate-docs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   invalidate-docs:
-    permissions: none
+    permissions: {}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The github ai bot suggested `permissions: none` but this is invalid, it needs to be `permissions: {}` for no permissions https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes-1