### PR TITLE
fix: Correct shell escape for branch name

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          encoded=$(printf '%s' "$$BRANCH_NAME" | jq -sRr @uri)
+          encoded=$(printf '%s' "$BRANCH_NAME" | jq -sRr @uri)
           echo "branch=$encoded" >> $GITHUB_OUTPUT
 
       - name: Find existing comment


### PR DESCRIPTION
Branch previews were not working properly. In 358a063 when we moved the branch name into an environment variable, we used `$$` which expands to the PID. (In a Makefile you need `$$` but this isn't a Makefile.)

You can see that the preview here is correct.