### PR TITLE
Update OpenAPI Specs

### DIFF
--- a/bapi/2021-02-05.yml
+++ b/bapi/2021-02-05.yml
@@ -589,9 +589,16 @@ paths:
         Replaces all of the user's email addresses with a single primary email address.
         By default the new email address is created verified, with the admin verification strategy.
         When `identification_status` is `reserved` it is created reserved instead: unverified but usable
-        for sign-in and locked so no other user can claim it. Any existing email addresses are deleted.
+        for sign-in and locked so no other user can claim it. When it is `unverified` the address is
+        neither usable for sign-in nor locked. Any existing email addresses are deleted.
         If an existing email address is linked to a connected account, the request is rejected; remove
         the connected account first.
+
+        **Warning:** `identification_status: unverified` can lock the user out of their account. An
+        unverified email address cannot be used to sign in, so if the user has no other verified or
+        reserved identifier, deleting their existing email addresses leaves them unable to
+        authenticate — and unable to verify the new address, since that requires signing in. Recovery
+        then requires another admin API call.
       parameters:
         - name: user_id
           in: path
@@ -615,11 +622,19 @@ paths:
                   enum:
                     - verified
                     - reserved
+                    - unverified
                   default: verified
                   description: |-
                     Controls the status of the replacement email address. Defaults to `verified`. Set to
-                    `reserved` to create it reserved (unverified but usable for sign-in and locked)
-                    instead of verified.
+                    `reserved` to create it reserved (unverified but usable for sign-in and locked so no
+                    other user can claim it), or to `unverified` to create it neither usable for sign-in
+                    nor locked.
+
+                    **Warning:** `unverified` can lock the user out of their account. An unverified email
+                    address cannot be used to sign in, so if the user has no other verified or reserved
+                    identifier, they will be unable to authenticate and unable to verify this address.
+                    Prefer `reserved` unless you specifically need the address left unclaimed — for
+                    example so that another user can also hold it until one of them verifies it.
                 notify_primary_email_address_changed:
                   type: boolean
                   description: |-
@@ -898,9 +913,16 @@ paths:
         Replaces all of the user's phone numbers with a single primary phone number.
         By default the new phone number is created verified, with the admin verification strategy.
         When `identification_status` is `reserved` it is created reserved instead: unverified but usable
-        for sign-in and locked so no other user can claim it. The new phone number is never reserved for
+        for sign-in and locked so no other user can claim it. When it is `unverified` the phone number is
+        neither usable for sign-in nor locked. The new phone number is never reserved for
         second factor. Any existing phone numbers are deleted; replacing a phone number that is reserved
         for second factor disables the user's MFA.
+
+        **Warning:** `identification_status: unverified` can lock the user out of their account. An
+        unverified phone number cannot be used to sign in, so if the user has no other verified or
+        reserved identifier, deleting their existing phone numbers leaves them unable to authenticate —
+        and unable to verify the new number, since that requires signing in. Recovery then requires
+        another admin API call.
       parameters:
         - name: user_id
           in: path
@@ -924,11 +946,19 @@ paths:
                   enum:
                     - verified
                     - reserved
+                    - unverified
                   default: verified
                   description: |-
                     Controls the status of the replacement phone number. Defaults to `verified`. Set to
-                    `reserved` to create it reserved (unverified but usable for sign-in and locked)
-                    instead of verified.
+                    `reserved` to create it reserved (unverified but usable for sign-in and locked so no
+                    other user can claim it), or to `unverified` to create it neither usable for sign-in
+                    nor locked.
+
+                    **Warning:** `unverified` can lock the user out of their account. An unverified phone
+                    number cannot be used to sign in, so if the user has no other verified or reserved
+                    identifier, they will be unable to authenticate and unable to verify this number.
+                    Prefer `reserved` unless you specifically need the number left unclaimed — for
+                    example so that another user can also hold it until one of them verifies it.
               required:
                 - phone_number
       responses:
@@ -3043,6 +3073,50 @@ paths:
           $ref: '#/components/responses/ClerkErrors'
         '404':
           $ref: '#/components/responses/ResourceNotFound'
+  /users/{user_id}/remove_password:
+    post:
+      operationId: RemoveUserPassword
+      x-speakeasy-group: users
+      x-speakeasy-name-override: removePassword
+      summary: Remove a user's password
+      description: |-
+        Removes the password credential from the given user. This is a privileged operation and does not require the user's current password. Password removal is allowed even when the user has no other sign-in method configured.
+
+        If the user does not have a password, the user is returned unchanged and no password-deletion or user-update event is emitted. By default, existing sessions remain active. Set `sign_out_of_other_sessions` to `true` to revoke sessions active when the request is processed.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user whose password to remove
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                sign_out_of_other_sessions:
+                  type: boolean
+                  default: false
+                  description: Set to `true` to revoke all of the user's active sessions after removing the password.
+      responses:
+        '200':
+          $ref: '#/components/responses/User'
+        '400':
+          $ref: '#/components/responses/ClerkErrors'
+        '401':
+          $ref: '#/components/responses/AuthenticationInvalid'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
   /users/{user_id}/verify_password:
     post:
       operationId: VerifyPassword
@@ -3240,6 +3314,62 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/DeletedObject'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
+  /users/{user_id}/trusted_devices:
+    get:
+      operationId: ListUserTrustedDevices
+      x-speakeasy-group: users
+      x-speakeasy-name-override: listTrustedDevices
+      summary: List a user's trusted devices
+      description: Returns the active trusted devices enrolled by the user.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user whose trusted devices are returned
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/TrustedDevice.List'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
+  /users/{user_id}/trusted_devices/{trusted_device_id}:
+    delete:
+      operationId: RevokeUserTrustedDevice
+      x-speakeasy-group: users
+      x-speakeasy-name-override: revokeTrustedDevice
+      summary: Revoke a user's trusted device
+      description: Revokes an active trusted device enrolled by the user.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user that owns the trusted device
+          required: true
+          schema:
+            type: string
+        - name: trusted_device_id
+          in: path
+          description: The ID of the trusted device to revoke
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/TrustedDevice'
         '403':
           $ref: '#/components/responses/AuthorizationInvalid'
         '404':
@@ -13947,6 +14077,63 @@ components:
       required:
         - data
         - total_count
+    TrustedDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - trusted_device
+          description: String representing the object's type.
+        id:
+          type: string
+        platform:
+          type: string
+          enum:
+            - ios
+            - android
+        app_identifier:
+          type: string
+        name:
+          type: string
+          nullable: true
+        algorithm:
+          type: string
+          enum:
+            - ES256
+        status:
+          type: string
+          enum:
+            - active
+            - revoked
+        created_at:
+          type: integer
+          format: int64
+          description: Unix timestamp of creation in milliseconds.
+        updated_at:
+          type: integer
+          format: int64
+          description: Unix timestamp of the last update in milliseconds.
+        last_used_at:
+          type: integer
+          format: int64
+          nullable: true
+          description: Unix timestamp of the last use in milliseconds.
+        revoked_at:
+          type: integer
+          format: int64
+          nullable: true
+          description: Unix timestamp of revocation in milliseconds.
+      required:
+        - object
+        - id
+        - platform
+        - app_identifier
+        - algorithm
+        - status
+        - created_at
+        - updated_at
     Invitation:
       type: object
       additionalProperties: false
@@ -17060,6 +17247,30 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/OrganizationInvitationsWithPublicOrganizationData'
+    TrustedDevice.List:
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+              - total_count
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrustedDevice'
+              total_count:
+                type: integer
+                format: int64
+                description: Total number of trusted devices
+    TrustedDevice:
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TrustedDevice'
     Invitation.List:
       description: List of invitations
       content:

--- a/bapi/2024-10-01.yml
+++ b/bapi/2024-10-01.yml
@@ -589,9 +589,16 @@ paths:
         Replaces all of the user's email addresses with a single primary email address.
         By default the new email address is created verified, with the admin verification strategy.
         When `identification_status` is `reserved` it is created reserved instead: unverified but usable
-        for sign-in and locked so no other user can claim it. Any existing email addresses are deleted.
+        for sign-in and locked so no other user can claim it. When it is `unverified` the address is
+        neither usable for sign-in nor locked. Any existing email addresses are deleted.
         If an existing email address is linked to a connected account, the request is rejected; remove
         the connected account first.
+
+        **Warning:** `identification_status: unverified` can lock the user out of their account. An
+        unverified email address cannot be used to sign in, so if the user has no other verified or
+        reserved identifier, deleting their existing email addresses leaves them unable to
+        authenticate — and unable to verify the new address, since that requires signing in. Recovery
+        then requires another admin API call.
       parameters:
         - name: user_id
           in: path
@@ -615,11 +622,19 @@ paths:
                   enum:
                     - verified
                     - reserved
+                    - unverified
                   default: verified
                   description: |-
                     Controls the status of the replacement email address. Defaults to `verified`. Set to
-                    `reserved` to create it reserved (unverified but usable for sign-in and locked)
-                    instead of verified.
+                    `reserved` to create it reserved (unverified but usable for sign-in and locked so no
+                    other user can claim it), or to `unverified` to create it neither usable for sign-in
+                    nor locked.
+
+                    **Warning:** `unverified` can lock the user out of their account. An unverified email
+                    address cannot be used to sign in, so if the user has no other verified or reserved
+                    identifier, they will be unable to authenticate and unable to verify this address.
+                    Prefer `reserved` unless you specifically need the address left unclaimed — for
+                    example so that another user can also hold it until one of them verifies it.
                 notify_primary_email_address_changed:
                   type: boolean
                   description: |-
@@ -898,9 +913,16 @@ paths:
         Replaces all of the user's phone numbers with a single primary phone number.
         By default the new phone number is created verified, with the admin verification strategy.
         When `identification_status` is `reserved` it is created reserved instead: unverified but usable
-        for sign-in and locked so no other user can claim it. The new phone number is never reserved for
+        for sign-in and locked so no other user can claim it. When it is `unverified` the phone number is
+        neither usable for sign-in nor locked. The new phone number is never reserved for
         second factor. Any existing phone numbers are deleted; replacing a phone number that is reserved
         for second factor disables the user's MFA.
+
+        **Warning:** `identification_status: unverified` can lock the user out of their account. An
+        unverified phone number cannot be used to sign in, so if the user has no other verified or
+        reserved identifier, deleting their existing phone numbers leaves them unable to authenticate —
+        and unable to verify the new number, since that requires signing in. Recovery then requires
+        another admin API call.
       parameters:
         - name: user_id
           in: path
@@ -924,11 +946,19 @@ paths:
                   enum:
                     - verified
                     - reserved
+                    - unverified
                   default: verified
                   description: |-
                     Controls the status of the replacement phone number. Defaults to `verified`. Set to
-                    `reserved` to create it reserved (unverified but usable for sign-in and locked)
-                    instead of verified.
+                    `reserved` to create it reserved (unverified but usable for sign-in and locked so no
+                    other user can claim it), or to `unverified` to create it neither usable for sign-in
+                    nor locked.
+
+                    **Warning:** `unverified` can lock the user out of their account. An unverified phone
+                    number cannot be used to sign in, so if the user has no other verified or reserved
+                    identifier, they will be unable to authenticate and unable to verify this number.
+                    Prefer `reserved` unless you specifically need the number left unclaimed — for
+                    example so that another user can also hold it until one of them verifies it.
               required:
                 - phone_number
       responses:
@@ -3043,6 +3073,50 @@ paths:
           $ref: '#/components/responses/ClerkErrors'
         '404':
           $ref: '#/components/responses/ResourceNotFound'
+  /users/{user_id}/remove_password:
+    post:
+      operationId: RemoveUserPassword
+      x-speakeasy-group: users
+      x-speakeasy-name-override: removePassword
+      summary: Remove a user's password
+      description: |-
+        Removes the password credential from the given user. This is a privileged operation and does not require the user's current password. Password removal is allowed even when the user has no other sign-in method configured.
+
+        If the user does not have a password, the user is returned unchanged and no password-deletion or user-update event is emitted. By default, existing sessions remain active. Set `sign_out_of_other_sessions` to `true` to revoke sessions active when the request is processed.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user whose password to remove
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                sign_out_of_other_sessions:
+                  type: boolean
+                  default: false
+                  description: Set to `true` to revoke all of the user's active sessions after removing the password.
+      responses:
+        '200':
+          $ref: '#/components/responses/User'
+        '400':
+          $ref: '#/components/responses/ClerkErrors'
+        '401':
+          $ref: '#/components/responses/AuthenticationInvalid'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
   /users/{user_id}/verify_password:
     post:
       operationId: VerifyPassword
@@ -3240,6 +3314,62 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/DeletedObject'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
+  /users/{user_id}/trusted_devices:
+    get:
+      operationId: ListUserTrustedDevices
+      x-speakeasy-group: users
+      x-speakeasy-name-override: listTrustedDevices
+      summary: List a user's trusted devices
+      description: Returns the active trusted devices enrolled by the user.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user whose trusted devices are returned
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/TrustedDevice.List'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
+  /users/{user_id}/trusted_devices/{trusted_device_id}:
+    delete:
+      operationId: RevokeUserTrustedDevice
+      x-speakeasy-group: users
+      x-speakeasy-name-override: revokeTrustedDevice
+      summary: Revoke a user's trusted device
+      description: Revokes an active trusted device enrolled by the user.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user that owns the trusted device
+          required: true
+          schema:
+            type: string
+        - name: trusted_device_id
+          in: path
+          description: The ID of the trusted device to revoke
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/TrustedDevice'
         '403':
           $ref: '#/components/responses/AuthorizationInvalid'
         '404':
@@ -14220,6 +14350,63 @@ components:
       required:
         - data
         - total_count
+    TrustedDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - trusted_device
+          description: String representing the object's type.
+        id:
+          type: string
+        platform:
+          type: string
+          enum:
+            - ios
+            - android
+        app_identifier:
+          type: string
+        name:
+          type: string
+          nullable: true
+        algorithm:
+          type: string
+          enum:
+            - ES256
+        status:
+          type: string
+          enum:
+            - active
+            - revoked
+        created_at:
+          type: integer
+          format: int64
+          description: Unix timestamp of creation in milliseconds.
+        updated_at:
+          type: integer
+          format: int64
+          description: Unix timestamp of the last update in milliseconds.
+        last_used_at:
+          type: integer
+          format: int64
+          nullable: true
+          description: Unix timestamp of the last use in milliseconds.
+        revoked_at:
+          type: integer
+          format: int64
+          nullable: true
+          description: Unix timestamp of revocation in milliseconds.
+      required:
+        - object
+        - id
+        - platform
+        - app_identifier
+        - algorithm
+        - status
+        - created_at
+        - updated_at
     Invitation:
       type: object
       additionalProperties: false
@@ -17393,6 +17580,30 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/OrganizationInvitationsWithPublicOrganizationData'
+    TrustedDevice.List:
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+              - total_count
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrustedDevice'
+              total_count:
+                type: integer
+                format: int64
+                description: Total number of trusted devices
+    TrustedDevice:
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TrustedDevice'
     Invitation.List:
       description: List of invitations
       content:

--- a/bapi/2025-04-10.yml
+++ b/bapi/2025-04-10.yml
@@ -592,9 +592,16 @@ paths:
         Replaces all of the user's email addresses with a single primary email address.
         By default the new email address is created verified, with the admin verification strategy.
         When `identification_status` is `reserved` it is created reserved instead: unverified but usable
-        for sign-in and locked so no other user can claim it. Any existing email addresses are deleted.
+        for sign-in and locked so no other user can claim it. When it is `unverified` the address is
+        neither usable for sign-in nor locked. Any existing email addresses are deleted.
         If an existing email address is linked to a connected account, the request is rejected; remove
         the connected account first.
+
+        **Warning:** `identification_status: unverified` can lock the user out of their account. An
+        unverified email address cannot be used to sign in, so if the user has no other verified or
+        reserved identifier, deleting their existing email addresses leaves them unable to
+        authenticate — and unable to verify the new address, since that requires signing in. Recovery
+        then requires another admin API call.
       parameters:
         - name: user_id
           in: path
@@ -618,11 +625,19 @@ paths:
                   enum:
                     - verified
                     - reserved
+                    - unverified
                   default: verified
                   description: |-
                     Controls the status of the replacement email address. Defaults to `verified`. Set to
-                    `reserved` to create it reserved (unverified but usable for sign-in and locked)
-                    instead of verified.
+                    `reserved` to create it reserved (unverified but usable for sign-in and locked so no
+                    other user can claim it), or to `unverified` to create it neither usable for sign-in
+                    nor locked.
+
+                    **Warning:** `unverified` can lock the user out of their account. An unverified email
+                    address cannot be used to sign in, so if the user has no other verified or reserved
+                    identifier, they will be unable to authenticate and unable to verify this address.
+                    Prefer `reserved` unless you specifically need the address left unclaimed — for
+                    example so that another user can also hold it until one of them verifies it.
                 notify_primary_email_address_changed:
                   type: boolean
                   description: |-
@@ -901,9 +916,16 @@ paths:
         Replaces all of the user's phone numbers with a single primary phone number.
         By default the new phone number is created verified, with the admin verification strategy.
         When `identification_status` is `reserved` it is created reserved instead: unverified but usable
-        for sign-in and locked so no other user can claim it. The new phone number is never reserved for
+        for sign-in and locked so no other user can claim it. When it is `unverified` the phone number is
+        neither usable for sign-in nor locked. The new phone number is never reserved for
         second factor. Any existing phone numbers are deleted; replacing a phone number that is reserved
         for second factor disables the user's MFA.
+
+        **Warning:** `identification_status: unverified` can lock the user out of their account. An
+        unverified phone number cannot be used to sign in, so if the user has no other verified or
+        reserved identifier, deleting their existing phone numbers leaves them unable to authenticate —
+        and unable to verify the new number, since that requires signing in. Recovery then requires
+        another admin API call.
       parameters:
         - name: user_id
           in: path
@@ -927,11 +949,19 @@ paths:
                   enum:
                     - verified
                     - reserved
+                    - unverified
                   default: verified
                   description: |-
                     Controls the status of the replacement phone number. Defaults to `verified`. Set to
-                    `reserved` to create it reserved (unverified but usable for sign-in and locked)
-                    instead of verified.
+                    `reserved` to create it reserved (unverified but usable for sign-in and locked so no
+                    other user can claim it), or to `unverified` to create it neither usable for sign-in
+                    nor locked.
+
+                    **Warning:** `unverified` can lock the user out of their account. An unverified phone
+                    number cannot be used to sign in, so if the user has no other verified or reserved
+                    identifier, they will be unable to authenticate and unable to verify this number.
+                    Prefer `reserved` unless you specifically need the number left unclaimed — for
+                    example so that another user can also hold it until one of them verifies it.
               required:
                 - phone_number
       responses:
@@ -3036,6 +3066,50 @@ paths:
           $ref: '#/components/responses/ClerkErrors'
         '404':
           $ref: '#/components/responses/ResourceNotFound'
+  /users/{user_id}/remove_password:
+    post:
+      operationId: RemoveUserPassword
+      x-speakeasy-group: users
+      x-speakeasy-name-override: removePassword
+      summary: Remove a user's password
+      description: |-
+        Removes the password credential from the given user. This is a privileged operation and does not require the user's current password. Password removal is allowed even when the user has no other sign-in method configured.
+
+        If the user does not have a password, the user is returned unchanged and no password-deletion or user-update event is emitted. By default, existing sessions remain active. Set `sign_out_of_other_sessions` to `true` to revoke sessions active when the request is processed.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user whose password to remove
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                sign_out_of_other_sessions:
+                  type: boolean
+                  default: false
+                  description: Set to `true` to revoke all of the user's active sessions after removing the password.
+      responses:
+        '200':
+          $ref: '#/components/responses/User'
+        '400':
+          $ref: '#/components/responses/ClerkErrors'
+        '401':
+          $ref: '#/components/responses/AuthenticationInvalid'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
   /users/{user_id}/verify_password:
     post:
       operationId: VerifyPassword
@@ -3233,6 +3307,62 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/DeletedObject'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
+  /users/{user_id}/trusted_devices:
+    get:
+      operationId: ListUserTrustedDevices
+      x-speakeasy-group: users
+      x-speakeasy-name-override: listTrustedDevices
+      summary: List a user's trusted devices
+      description: Returns the active trusted devices enrolled by the user.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user whose trusted devices are returned
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/TrustedDevice.List'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
+  /users/{user_id}/trusted_devices/{trusted_device_id}:
+    delete:
+      operationId: RevokeUserTrustedDevice
+      x-speakeasy-group: users
+      x-speakeasy-name-override: revokeTrustedDevice
+      summary: Revoke a user's trusted device
+      description: Revokes an active trusted device enrolled by the user.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user that owns the trusted device
+          required: true
+          schema:
+            type: string
+        - name: trusted_device_id
+          in: path
+          description: The ID of the trusted device to revoke
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/TrustedDevice'
         '403':
           $ref: '#/components/responses/AuthorizationInvalid'
         '404':
@@ -14947,6 +15077,63 @@ components:
       required:
         - data
         - total_count
+    TrustedDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - trusted_device
+          description: String representing the object's type.
+        id:
+          type: string
+        platform:
+          type: string
+          enum:
+            - ios
+            - android
+        app_identifier:
+          type: string
+        name:
+          type: string
+          nullable: true
+        algorithm:
+          type: string
+          enum:
+            - ES256
+        status:
+          type: string
+          enum:
+            - active
+            - revoked
+        created_at:
+          type: integer
+          format: int64
+          description: Unix timestamp of creation in milliseconds.
+        updated_at:
+          type: integer
+          format: int64
+          description: Unix timestamp of the last update in milliseconds.
+        last_used_at:
+          type: integer
+          format: int64
+          nullable: true
+          description: Unix timestamp of the last use in milliseconds.
+        revoked_at:
+          type: integer
+          format: int64
+          nullable: true
+          description: Unix timestamp of revocation in milliseconds.
+      required:
+        - object
+        - id
+        - platform
+        - app_identifier
+        - algorithm
+        - status
+        - created_at
+        - updated_at
     Invitation:
       type: object
       additionalProperties: false
@@ -17405,6 +17592,30 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/OrganizationInvitationsWithPublicOrganizationData'
+    TrustedDevice.List:
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+              - total_count
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrustedDevice'
+              total_count:
+                type: integer
+                format: int64
+                description: Total number of trusted devices
+    TrustedDevice:
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TrustedDevice'
     Invitation.List:
       description: List of invitations
       content:

--- a/bapi/2025-11-10.yml
+++ b/bapi/2025-11-10.yml
@@ -598,9 +598,16 @@ paths:
         Replaces all of the user's email addresses with a single primary email address.
         By default the new email address is created verified, with the admin verification strategy.
         When `identification_status` is `reserved` it is created reserved instead: unverified but usable
-        for sign-in and locked so no other user can claim it. Any existing email addresses are deleted.
+        for sign-in and locked so no other user can claim it. When it is `unverified` the address is
+        neither usable for sign-in nor locked. Any existing email addresses are deleted.
         If an existing email address is linked to a connected account, the request is rejected; remove
         the connected account first.
+
+        **Warning:** `identification_status: unverified` can lock the user out of their account. An
+        unverified email address cannot be used to sign in, so if the user has no other verified or
+        reserved identifier, deleting their existing email addresses leaves them unable to
+        authenticate — and unable to verify the new address, since that requires signing in. Recovery
+        then requires another admin API call.
       parameters:
         - name: user_id
           in: path
@@ -624,11 +631,19 @@ paths:
                   enum:
                     - verified
                     - reserved
+                    - unverified
                   default: verified
                   description: |-
                     Controls the status of the replacement email address. Defaults to `verified`. Set to
-                    `reserved` to create it reserved (unverified but usable for sign-in and locked)
-                    instead of verified.
+                    `reserved` to create it reserved (unverified but usable for sign-in and locked so no
+                    other user can claim it), or to `unverified` to create it neither usable for sign-in
+                    nor locked.
+
+                    **Warning:** `unverified` can lock the user out of their account. An unverified email
+                    address cannot be used to sign in, so if the user has no other verified or reserved
+                    identifier, they will be unable to authenticate and unable to verify this address.
+                    Prefer `reserved` unless you specifically need the address left unclaimed — for
+                    example so that another user can also hold it until one of them verifies it.
                 notify_primary_email_address_changed:
                   type: boolean
                   description: |-
@@ -907,9 +922,16 @@ paths:
         Replaces all of the user's phone numbers with a single primary phone number.
         By default the new phone number is created verified, with the admin verification strategy.
         When `identification_status` is `reserved` it is created reserved instead: unverified but usable
-        for sign-in and locked so no other user can claim it. The new phone number is never reserved for
+        for sign-in and locked so no other user can claim it. When it is `unverified` the phone number is
+        neither usable for sign-in nor locked. The new phone number is never reserved for
         second factor. Any existing phone numbers are deleted; replacing a phone number that is reserved
         for second factor disables the user's MFA.
+
+        **Warning:** `identification_status: unverified` can lock the user out of their account. An
+        unverified phone number cannot be used to sign in, so if the user has no other verified or
+        reserved identifier, deleting their existing phone numbers leaves them unable to authenticate —
+        and unable to verify the new number, since that requires signing in. Recovery then requires
+        another admin API call.
       parameters:
         - name: user_id
           in: path
@@ -933,11 +955,19 @@ paths:
                   enum:
                     - verified
                     - reserved
+                    - unverified
                   default: verified
                   description: |-
                     Controls the status of the replacement phone number. Defaults to `verified`. Set to
-                    `reserved` to create it reserved (unverified but usable for sign-in and locked)
-                    instead of verified.
+                    `reserved` to create it reserved (unverified but usable for sign-in and locked so no
+                    other user can claim it), or to `unverified` to create it neither usable for sign-in
+                    nor locked.
+
+                    **Warning:** `unverified` can lock the user out of their account. An unverified phone
+                    number cannot be used to sign in, so if the user has no other verified or reserved
+                    identifier, they will be unable to authenticate and unable to verify this number.
+                    Prefer `reserved` unless you specifically need the number left unclaimed — for
+                    example so that another user can also hold it until one of them verifies it.
               required:
                 - phone_number
       responses:
@@ -3042,6 +3072,50 @@ paths:
           $ref: '#/components/responses/ClerkErrors'
         '404':
           $ref: '#/components/responses/ResourceNotFound'
+  /users/{user_id}/remove_password:
+    post:
+      operationId: RemoveUserPassword
+      x-speakeasy-group: users
+      x-speakeasy-name-override: removePassword
+      summary: Remove a user's password
+      description: |-
+        Removes the password credential from the given user. This is a privileged operation and does not require the user's current password. Password removal is allowed even when the user has no other sign-in method configured.
+
+        If the user does not have a password, the user is returned unchanged and no password-deletion or user-update event is emitted. By default, existing sessions remain active. Set `sign_out_of_other_sessions` to `true` to revoke sessions active when the request is processed.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user whose password to remove
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                sign_out_of_other_sessions:
+                  type: boolean
+                  default: false
+                  description: Set to `true` to revoke all of the user's active sessions after removing the password.
+      responses:
+        '200':
+          $ref: '#/components/responses/User'
+        '400':
+          $ref: '#/components/responses/ClerkErrors'
+        '401':
+          $ref: '#/components/responses/AuthenticationInvalid'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
   /users/{user_id}/verify_password:
     post:
       operationId: VerifyPassword
@@ -3239,6 +3313,62 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/DeletedObject'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
+  /users/{user_id}/trusted_devices:
+    get:
+      operationId: ListUserTrustedDevices
+      x-speakeasy-group: users
+      x-speakeasy-name-override: listTrustedDevices
+      summary: List a user's trusted devices
+      description: Returns the active trusted devices enrolled by the user.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user whose trusted devices are returned
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/TrustedDevice.List'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
+  /users/{user_id}/trusted_devices/{trusted_device_id}:
+    delete:
+      operationId: RevokeUserTrustedDevice
+      x-speakeasy-group: users
+      x-speakeasy-name-override: revokeTrustedDevice
+      summary: Revoke a user's trusted device
+      description: Revokes an active trusted device enrolled by the user.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user that owns the trusted device
+          required: true
+          schema:
+            type: string
+        - name: trusted_device_id
+          in: path
+          description: The ID of the trusted device to revoke
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/TrustedDevice'
         '403':
           $ref: '#/components/responses/AuthorizationInvalid'
         '404':
@@ -15614,6 +15744,63 @@ components:
       required:
         - data
         - total_count
+    TrustedDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - trusted_device
+          description: String representing the object's type.
+        id:
+          type: string
+        platform:
+          type: string
+          enum:
+            - ios
+            - android
+        app_identifier:
+          type: string
+        name:
+          type: string
+          nullable: true
+        algorithm:
+          type: string
+          enum:
+            - ES256
+        status:
+          type: string
+          enum:
+            - active
+            - revoked
+        created_at:
+          type: integer
+          format: int64
+          description: Unix timestamp of creation in milliseconds.
+        updated_at:
+          type: integer
+          format: int64
+          description: Unix timestamp of the last update in milliseconds.
+        last_used_at:
+          type: integer
+          format: int64
+          nullable: true
+          description: Unix timestamp of the last use in milliseconds.
+        revoked_at:
+          type: integer
+          format: int64
+          nullable: true
+          description: Unix timestamp of revocation in milliseconds.
+      required:
+        - object
+        - id
+        - platform
+        - app_identifier
+        - algorithm
+        - status
+        - created_at
+        - updated_at
     Invitation:
       type: object
       additionalProperties: false
@@ -18899,6 +19086,30 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/OrganizationInvitationsWithPublicOrganizationData'
+    TrustedDevice.List:
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+              - total_count
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrustedDevice'
+              total_count:
+                type: integer
+                format: int64
+                description: Total number of trusted devices
+    TrustedDevice:
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TrustedDevice'
     Invitation.List:
       description: List of invitations
       content:

--- a/bapi/2026-05-12.yml
+++ b/bapi/2026-05-12.yml
@@ -598,9 +598,16 @@ paths:
         Replaces all of the user's email addresses with a single primary email address.
         By default the new email address is created verified, with the admin verification strategy.
         When `identification_status` is `reserved` it is created reserved instead: unverified but usable
-        for sign-in and locked so no other user can claim it. Any existing email addresses are deleted.
+        for sign-in and locked so no other user can claim it. When it is `unverified` the address is
+        neither usable for sign-in nor locked. Any existing email addresses are deleted.
         If an existing email address is linked to a connected account, the request is rejected; remove
         the connected account first.
+
+        **Warning:** `identification_status: unverified` can lock the user out of their account. An
+        unverified email address cannot be used to sign in, so if the user has no other verified or
+        reserved identifier, deleting their existing email addresses leaves them unable to
+        authenticate — and unable to verify the new address, since that requires signing in. Recovery
+        then requires another admin API call.
       parameters:
         - name: user_id
           in: path
@@ -624,11 +631,19 @@ paths:
                   enum:
                     - verified
                     - reserved
+                    - unverified
                   default: verified
                   description: |-
                     Controls the status of the replacement email address. Defaults to `verified`. Set to
-                    `reserved` to create it reserved (unverified but usable for sign-in and locked)
-                    instead of verified.
+                    `reserved` to create it reserved (unverified but usable for sign-in and locked so no
+                    other user can claim it), or to `unverified` to create it neither usable for sign-in
+                    nor locked.
+
+                    **Warning:** `unverified` can lock the user out of their account. An unverified email
+                    address cannot be used to sign in, so if the user has no other verified or reserved
+                    identifier, they will be unable to authenticate and unable to verify this address.
+                    Prefer `reserved` unless you specifically need the address left unclaimed — for
+                    example so that another user can also hold it until one of them verifies it.
                 notify_primary_email_address_changed:
                   type: boolean
                   description: |-
@@ -907,9 +922,16 @@ paths:
         Replaces all of the user's phone numbers with a single primary phone number.
         By default the new phone number is created verified, with the admin verification strategy.
         When `identification_status` is `reserved` it is created reserved instead: unverified but usable
-        for sign-in and locked so no other user can claim it. The new phone number is never reserved for
+        for sign-in and locked so no other user can claim it. When it is `unverified` the phone number is
+        neither usable for sign-in nor locked. The new phone number is never reserved for
         second factor. Any existing phone numbers are deleted; replacing a phone number that is reserved
         for second factor disables the user's MFA.
+
+        **Warning:** `identification_status: unverified` can lock the user out of their account. An
+        unverified phone number cannot be used to sign in, so if the user has no other verified or
+        reserved identifier, deleting their existing phone numbers leaves them unable to authenticate —
+        and unable to verify the new number, since that requires signing in. Recovery then requires
+        another admin API call.
       parameters:
         - name: user_id
           in: path
@@ -933,11 +955,19 @@ paths:
                   enum:
                     - verified
                     - reserved
+                    - unverified
                   default: verified
                   description: |-
                     Controls the status of the replacement phone number. Defaults to `verified`. Set to
-                    `reserved` to create it reserved (unverified but usable for sign-in and locked)
-                    instead of verified.
+                    `reserved` to create it reserved (unverified but usable for sign-in and locked so no
+                    other user can claim it), or to `unverified` to create it neither usable for sign-in
+                    nor locked.
+
+                    **Warning:** `unverified` can lock the user out of their account. An unverified phone
+                    number cannot be used to sign in, so if the user has no other verified or reserved
+                    identifier, they will be unable to authenticate and unable to verify this number.
+                    Prefer `reserved` unless you specifically need the number left unclaimed — for
+                    example so that another user can also hold it until one of them verifies it.
               required:
                 - phone_number
       responses:
@@ -3005,6 +3035,50 @@ paths:
           $ref: '#/components/responses/ClerkErrors'
         '404':
           $ref: '#/components/responses/ResourceNotFound'
+  /users/{user_id}/remove_password:
+    post:
+      operationId: RemoveUserPassword
+      x-speakeasy-group: users
+      x-speakeasy-name-override: removePassword
+      summary: Remove a user's password
+      description: |-
+        Removes the password credential from the given user. This is a privileged operation and does not require the user's current password. Password removal is allowed even when the user has no other sign-in method configured.
+
+        If the user does not have a password, the user is returned unchanged and no password-deletion or user-update event is emitted. By default, existing sessions remain active. Set `sign_out_of_other_sessions` to `true` to revoke sessions active when the request is processed.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user whose password to remove
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                sign_out_of_other_sessions:
+                  type: boolean
+                  default: false
+                  description: Set to `true` to revoke all of the user's active sessions after removing the password.
+      responses:
+        '200':
+          $ref: '#/components/responses/User'
+        '400':
+          $ref: '#/components/responses/ClerkErrors'
+        '401':
+          $ref: '#/components/responses/AuthenticationInvalid'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
   /users/{user_id}/verify_password:
     post:
       operationId: VerifyPassword
@@ -3202,6 +3276,62 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/DeletedObject'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
+  /users/{user_id}/trusted_devices:
+    get:
+      operationId: ListUserTrustedDevices
+      x-speakeasy-group: users
+      x-speakeasy-name-override: listTrustedDevices
+      summary: List a user's trusted devices
+      description: Returns the active trusted devices enrolled by the user.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user whose trusted devices are returned
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/TrustedDevice.List'
+        '403':
+          $ref: '#/components/responses/AuthorizationInvalid'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '500':
+          $ref: '#/components/responses/ClerkErrors'
+  /users/{user_id}/trusted_devices/{trusted_device_id}:
+    delete:
+      operationId: RevokeUserTrustedDevice
+      x-speakeasy-group: users
+      x-speakeasy-name-override: revokeTrustedDevice
+      summary: Revoke a user's trusted device
+      description: Revokes an active trusted device enrolled by the user.
+      tags:
+        - Users
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user that owns the trusted device
+          required: true
+          schema:
+            type: string
+        - name: trusted_device_id
+          in: path
+          description: The ID of the trusted device to revoke
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/TrustedDevice'
         '403':
           $ref: '#/components/responses/AuthorizationInvalid'
         '404':
@@ -15766,6 +15896,63 @@ components:
       required:
         - data
         - total_count
+    TrustedDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - trusted_device
+          description: String representing the object's type.
+        id:
+          type: string
+        platform:
+          type: string
+          enum:
+            - ios
+            - android
+        app_identifier:
+          type: string
+        name:
+          type: string
+          nullable: true
+        algorithm:
+          type: string
+          enum:
+            - ES256
+        status:
+          type: string
+          enum:
+            - active
+            - revoked
+        created_at:
+          type: integer
+          format: int64
+          description: Unix timestamp of creation in milliseconds.
+        updated_at:
+          type: integer
+          format: int64
+          description: Unix timestamp of the last update in milliseconds.
+        last_used_at:
+          type: integer
+          format: int64
+          nullable: true
+          description: Unix timestamp of the last use in milliseconds.
+        revoked_at:
+          type: integer
+          format: int64
+          nullable: true
+          description: Unix timestamp of revocation in milliseconds.
+      required:
+        - object
+        - id
+        - platform
+        - app_identifier
+        - algorithm
+        - status
+        - created_at
+        - updated_at
     Invitation:
       type: object
       additionalProperties: false
@@ -19098,6 +19285,30 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/OrganizationInvitationsWithPublicOrganizationData'
+    TrustedDevice.List:
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+              - total_count
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrustedDevice'
+              total_count:
+                type: integer
+                format: int64
+                description: Total number of trusted devices
+    TrustedDevice:
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TrustedDevice'
     Invitation.List:
       description: List of invitations
       content:

--- a/fapi/2021-02-05.yml
+++ b/fapi/2021-02-05.yml
@@ -8062,6 +8062,28 @@ components:
         - after_leave_organization_url
         - logo_link_url
         - customization
+    Client.NativeSettings:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - native_settings
+        api_enabled:
+          type: boolean
+        trusted_device_sign_in_enabled:
+          type: boolean
+        trusted_device_enrollment_prompt_after_sign_in_enabled:
+          type: boolean
+        trusted_device_enrollment_prompt_after_sign_up_enabled:
+          type: boolean
+      required:
+        - object
+        - api_enabled
+        - trusted_device_sign_in_enabled
+        - trusted_device_enrollment_prompt_after_sign_in_enabled
+        - trusted_device_enrollment_prompt_after_sign_up_enabled
     Client.AuthConfig:
       type: object
       additionalProperties: false
@@ -8148,6 +8170,8 @@ components:
           nullable: true
         reverification:
           type: boolean
+        native_settings:
+          $ref: '#/components/schemas/Client.NativeSettings'
       required:
         - object
         - id
@@ -8168,6 +8192,7 @@ components:
         - url_based_session_syncing
         - claimed_at
         - reverification
+        - native_settings
     Image:
       type: object
       properties:
@@ -10429,6 +10454,7 @@ components:
             - reset_password_email_code
             - reset_password_phone_code
             - passkey
+            - trusted_device
             - google_one_tap
         safe_identifier:
           type: string
@@ -10443,6 +10469,8 @@ components:
         web3_wallet_id:
           type: string
         passkey_id:
+          type: string
+        trusted_device_id:
           type: string
         primary:
           type: boolean
@@ -10512,6 +10540,67 @@ components:
         attempts:
           type: integer
           nullable: true
+      required:
+        - status
+        - strategy
+        - expire_at
+    Stubs.Verification.TrustedDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - verification_trusted_device
+        status:
+          type: string
+          enum:
+            - unverified
+            - verified
+            - failed
+            - expired
+        strategy:
+          type: string
+          enum:
+            - trusted_device
+        attempts:
+          type: integer
+          nullable: true
+        expire_at:
+          type: integer
+          nullable: true
+        trusted_device_challenge:
+          type: object
+          nullable: true
+          additionalProperties: false
+          properties:
+            object:
+              type: string
+              enum:
+                - trusted_device_challenge
+            challenge:
+              type: string
+            challenge_id:
+              type: string
+            trusted_device_id:
+              type: string
+            client_data:
+              type: string
+            expires_at:
+              type: integer
+              format: int64
+            algorithm:
+              type: string
+              enum:
+                - ES256
+          required:
+            - object
+            - challenge
+            - challenge_id
+            - trusted_device_id
+            - client_data
+            - expires_at
+            - algorithm
       required:
         - status
         - strategy
@@ -10649,6 +10738,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Ticket'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.GoogleOneTap'
         second_factor_verification:
           type: object
@@ -11280,6 +11370,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Ticket'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.GoogleOneTap'
         second_factor_verification:
           type: object
@@ -11558,6 +11649,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Password'
             - $ref: '#/components/schemas/Stubs.Verification.OTP'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
         second_factor_verification:
           type: object
           nullable: true

--- a/fapi/2024-10-01.yml
+++ b/fapi/2024-10-01.yml
@@ -7182,6 +7182,28 @@ components:
         - after_leave_organization_url
         - logo_link_url
         - customization
+    Client.NativeSettings:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - native_settings
+        api_enabled:
+          type: boolean
+        trusted_device_sign_in_enabled:
+          type: boolean
+        trusted_device_enrollment_prompt_after_sign_in_enabled:
+          type: boolean
+        trusted_device_enrollment_prompt_after_sign_up_enabled:
+          type: boolean
+      required:
+        - object
+        - api_enabled
+        - trusted_device_sign_in_enabled
+        - trusted_device_enrollment_prompt_after_sign_in_enabled
+        - trusted_device_enrollment_prompt_after_sign_up_enabled
     Client.AuthConfig:
       type: object
       additionalProperties: false
@@ -7268,6 +7290,8 @@ components:
           nullable: true
         reverification:
           type: boolean
+        native_settings:
+          $ref: '#/components/schemas/Client.NativeSettings'
       required:
         - object
         - id
@@ -7288,6 +7312,7 @@ components:
         - url_based_session_syncing
         - claimed_at
         - reverification
+        - native_settings
     Image:
       type: object
       properties:
@@ -9370,6 +9395,7 @@ components:
             - reset_password_email_code
             - reset_password_phone_code
             - passkey
+            - trusted_device
             - google_one_tap
         safe_identifier:
           type: string
@@ -9384,6 +9410,8 @@ components:
         web3_wallet_id:
           type: string
         passkey_id:
+          type: string
+        trusted_device_id:
           type: string
         primary:
           type: boolean
@@ -9453,6 +9481,67 @@ components:
         attempts:
           type: integer
           nullable: true
+      required:
+        - status
+        - strategy
+        - expire_at
+    Stubs.Verification.TrustedDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - verification_trusted_device
+        status:
+          type: string
+          enum:
+            - unverified
+            - verified
+            - failed
+            - expired
+        strategy:
+          type: string
+          enum:
+            - trusted_device
+        attempts:
+          type: integer
+          nullable: true
+        expire_at:
+          type: integer
+          nullable: true
+        trusted_device_challenge:
+          type: object
+          nullable: true
+          additionalProperties: false
+          properties:
+            object:
+              type: string
+              enum:
+                - trusted_device_challenge
+            challenge:
+              type: string
+            challenge_id:
+              type: string
+            trusted_device_id:
+              type: string
+            client_data:
+              type: string
+            expires_at:
+              type: integer
+              format: int64
+            algorithm:
+              type: string
+              enum:
+                - ES256
+          required:
+            - object
+            - challenge
+            - challenge_id
+            - trusted_device_id
+            - client_data
+            - expires_at
+            - algorithm
       required:
         - status
         - strategy
@@ -9590,6 +9679,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Ticket'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.GoogleOneTap'
         second_factor_verification:
           type: object
@@ -10052,6 +10142,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Password'
             - $ref: '#/components/schemas/Stubs.Verification.OTP'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
         second_factor_verification:
           type: object
           nullable: true
@@ -10475,6 +10566,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Ticket'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.GoogleOneTap'
         second_factor_verification:
           type: object

--- a/fapi/2025-04-10.yml
+++ b/fapi/2025-04-10.yml
@@ -1512,6 +1512,8 @@ paths:
 
         If the strategy equals `passkey` then no identifier is provided.
 
+        If the strategy equals `trusted_device` then trusted_device_id is required.
+
         If the strategy equals `google_one_tap` then token is required.
       tags:
         - Sign Ins
@@ -1533,7 +1535,7 @@ paths:
                   type: string
                   description: |-
                     Strategy used to sign in.
-                    Can be one of `phone_code`, `email_code`, `ticket`, `web3_[provider]_signature` `reset_password_code`, `reset_password_phone_code`, `email_link`, `oauth_[provider]`, `oauth_token_[provider]`, `saml`, `password`, `passkey`, `google_one_tap`
+                    Can be one of `phone_code`, `email_code`, `ticket`, `web3_[provider]_signature` `reset_password_code`, `reset_password_phone_code`, `email_link`, `oauth_[provider]`, `oauth_token_[provider]`, `saml`, `password`, `passkey`, `trusted_device`, `google_one_tap`
                   nullable: true
                 identifier:
                   type: string
@@ -1575,6 +1577,10 @@ paths:
                 proof_token:
                   type: string
                   description: Proof token produced by the Clerk Protect SDK.
+                  nullable: true
+                trusted_device_id:
+                  type: string
+                  description: Used with the `trusted_device` strategy.
                   nullable: true
       responses:
         '200':
@@ -1668,6 +1674,7 @@ paths:
         If the strategy equals phone_code then this request will send an SMS with an OTP code.
         If the strategy equals oauth_[provider] then this request generate a URL that the User needs to visit in order to authenticate.
         If the strategy equals passkey then this request will begin the passkey registration flow.
+        If the strategy equals trusted_device then this request will issue a trusted-device sign-in challenge.
 
         Parameter rules:
         If the strategy equals `oauth_[provider]` then a redirect_url is required, and an action_complete_redirect_url is optional.
@@ -1700,7 +1707,7 @@ paths:
                     Can be one of the following `email_code`, `email_link`,
                     `phone_code`, `web3_metamask_signature`, `web3_base_signature`, `web3_coinbase_wallet_signature`,
                     `web3_okx_wallet_signature`, `reset_password_phone_code`, `reset_password_email_code`,
-                    `oauth_[provider]`, `saml`, `passkey`, `enterprise_sso`
+                    `oauth_[provider]`, `saml`, `passkey`, `trusted_device`, `enterprise_sso`
                 email_address_id:
                   type: string
                   description: Used with the `email_code`, `reset_password_email_code` and `email_link` strategies.
@@ -1720,6 +1727,10 @@ paths:
                 passkey_id:
                   type: string
                   description: Used with the `passkey` strategy.
+                  nullable: true
+                trusted_device_id:
+                  type: string
+                  description: Used with the `trusted_device` strategy.
                   nullable: true
                 redirect_url:
                   type: string
@@ -1764,6 +1775,7 @@ paths:
         Parameter rules:
         If the strategy equals `email_code` or `phone_code` then a code is required.
         If the strategy equals `password` then a password is required.
+        If the strategy equals `trusted_device` then trusted_device_id, client_data, signature and algorithm are required.
       tags:
         - Sign Ins
       operationId: attemptSignInFactorOne
@@ -1792,7 +1804,7 @@ paths:
 
                     Can be one of the following `email_code`, `email_link`, `password`, `phone_code`,
                     `web3_metamask_signature`, `web3_base_signature`, `web3_coinbase_wallet_signature`, `web3_okx_wallet_signature`,
-                    `reset_password_phone_code`, `reset_password_email_code`, `passkey`, `google_one_tap`
+                    `reset_password_phone_code`, `reset_password_email_code`, `passkey`, `trusted_device`, `google_one_tap`
                 code:
                   type: string
                   description: The code that was sent to the email. Used with the `email_code`, `phone_code`, and `email_link` strategies.
@@ -1803,7 +1815,7 @@ paths:
                   nullable: true
                 signature:
                   type: string
-                  description: Used with the `web3_metamask_signature`, `web3_base_signature`, `web3_coinbase_wallet_signature` and `web3_okx_wallet_signature` strategies.
+                  description: Used with the `web3_metamask_signature`, `web3_base_signature`, `web3_coinbase_wallet_signature`, `web3_okx_wallet_signature`, and `trusted_device` strategies.
                   nullable: true
                 token:
                   type: string
@@ -1816,6 +1828,20 @@ paths:
                 public_key_credential:
                   type: string
                   description: Used with the `passkey` strategy.
+                  nullable: true
+                trusted_device_id:
+                  type: string
+                  description: Used with the `trusted_device` strategy.
+                  nullable: true
+                client_data:
+                  type: string
+                  description: Canonical trusted-device challenge payload returned by prepare.
+                  nullable: true
+                algorithm:
+                  type: string
+                  enum:
+                    - ES256
+                  description: Signature algorithm used with the `trusted_device` strategy.
                   nullable: true
               required:
                 - strategy
@@ -7500,6 +7526,28 @@ components:
         - after_leave_organization_url
         - logo_link_url
         - customization
+    Client.NativeSettings:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - native_settings
+        api_enabled:
+          type: boolean
+        trusted_device_sign_in_enabled:
+          type: boolean
+        trusted_device_enrollment_prompt_after_sign_in_enabled:
+          type: boolean
+        trusted_device_enrollment_prompt_after_sign_up_enabled:
+          type: boolean
+      required:
+        - object
+        - api_enabled
+        - trusted_device_sign_in_enabled
+        - trusted_device_enrollment_prompt_after_sign_in_enabled
+        - trusted_device_enrollment_prompt_after_sign_up_enabled
     Client.AuthConfig:
       type: object
       additionalProperties: false
@@ -7586,6 +7634,8 @@ components:
           nullable: true
         reverification:
           type: boolean
+        native_settings:
+          $ref: '#/components/schemas/Client.NativeSettings'
       required:
         - object
         - id
@@ -7606,6 +7656,7 @@ components:
         - url_based_session_syncing
         - claimed_at
         - reverification
+        - native_settings
     Image:
       type: object
       properties:
@@ -9716,6 +9767,7 @@ components:
             - reset_password_email_code
             - reset_password_phone_code
             - passkey
+            - trusted_device
             - google_one_tap
         safe_identifier:
           type: string
@@ -9730,6 +9782,8 @@ components:
         web3_wallet_id:
           type: string
         passkey_id:
+          type: string
+        trusted_device_id:
           type: string
         primary:
           type: boolean
@@ -9799,6 +9853,67 @@ components:
         attempts:
           type: integer
           nullable: true
+      required:
+        - status
+        - strategy
+        - expire_at
+    Stubs.Verification.TrustedDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - verification_trusted_device
+        status:
+          type: string
+          enum:
+            - unverified
+            - verified
+            - failed
+            - expired
+        strategy:
+          type: string
+          enum:
+            - trusted_device
+        attempts:
+          type: integer
+          nullable: true
+        expire_at:
+          type: integer
+          nullable: true
+        trusted_device_challenge:
+          type: object
+          nullable: true
+          additionalProperties: false
+          properties:
+            object:
+              type: string
+              enum:
+                - trusted_device_challenge
+            challenge:
+              type: string
+            challenge_id:
+              type: string
+            trusted_device_id:
+              type: string
+            client_data:
+              type: string
+            expires_at:
+              type: integer
+              format: int64
+            algorithm:
+              type: string
+              enum:
+                - ES256
+          required:
+            - object
+            - challenge
+            - challenge_id
+            - trusted_device_id
+            - client_data
+            - expires_at
+            - algorithm
       required:
         - status
         - strategy
@@ -9936,6 +10051,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Ticket'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.GoogleOneTap'
         second_factor_verification:
           type: object
@@ -10542,6 +10658,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Ticket'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.GoogleOneTap'
         second_factor_verification:
           type: object
@@ -10868,6 +10985,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Password'
             - $ref: '#/components/schemas/Stubs.Verification.OTP'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
         second_factor_verification:
           type: object

--- a/fapi/2025-11-10.yml
+++ b/fapi/2025-11-10.yml
@@ -1227,6 +1227,8 @@ paths:
 
         If the strategy equals `passkey` then no identifier is provided.
 
+        If the strategy equals `trusted_device` then trusted_device_id is required.
+
         If the strategy equals `google_one_tap` then token is required.
       tags:
         - Sign Ins
@@ -1248,7 +1250,7 @@ paths:
                   type: string
                   description: |-
                     Strategy used to sign in.
-                    Can be one of `phone_code`, `email_code`, `ticket`, `web3_[provider]_signature` `reset_password_code`, `reset_password_phone_code`, `email_link`, `oauth_[provider]`, `oauth_token_[provider]`, `saml`, `password`, `passkey`, `google_one_tap`
+                    Can be one of `phone_code`, `email_code`, `ticket`, `web3_[provider]_signature` `reset_password_code`, `reset_password_phone_code`, `email_link`, `oauth_[provider]`, `oauth_token_[provider]`, `saml`, `password`, `passkey`, `trusted_device`, `google_one_tap`
                   nullable: true
                 identifier:
                   type: string
@@ -1290,6 +1292,10 @@ paths:
                 proof_token:
                   type: string
                   description: Proof token produced by the Clerk Protect SDK.
+                  nullable: true
+                trusted_device_id:
+                  type: string
+                  description: Used with the `trusted_device` strategy.
                   nullable: true
       responses:
         '200':
@@ -1383,6 +1389,7 @@ paths:
         If the strategy equals phone_code then this request will send an SMS with an OTP code.
         If the strategy equals oauth_[provider] then this request generate a URL that the User needs to visit in order to authenticate.
         If the strategy equals passkey then this request will begin the passkey registration flow.
+        If the strategy equals trusted_device then this request will issue a trusted-device sign-in challenge.
 
         Parameter rules:
         If the strategy equals `oauth_[provider]` then a redirect_url is required, and an action_complete_redirect_url is optional.
@@ -1415,7 +1422,7 @@ paths:
                     Can be one of the following `email_code`, `email_link`,
                     `phone_code`, `web3_metamask_signature`, `web3_base_signature`, `web3_coinbase_wallet_signature`,
                     `web3_okx_wallet_signature`, `reset_password_phone_code`, `reset_password_email_code`,
-                    `oauth_[provider]`, `saml`, `passkey`, `enterprise_sso`
+                    `oauth_[provider]`, `saml`, `passkey`, `trusted_device`, `enterprise_sso`
                 email_address_id:
                   type: string
                   description: Used with the `email_code`, `reset_password_email_code` and `email_link` strategies.
@@ -1435,6 +1442,10 @@ paths:
                 passkey_id:
                   type: string
                   description: Used with the `passkey` strategy.
+                  nullable: true
+                trusted_device_id:
+                  type: string
+                  description: Used with the `trusted_device` strategy.
                   nullable: true
                 redirect_url:
                   type: string
@@ -1479,6 +1490,7 @@ paths:
         Parameter rules:
         If the strategy equals `email_code` or `phone_code` then a code is required.
         If the strategy equals `password` then a password is required.
+        If the strategy equals `trusted_device` then trusted_device_id, client_data, signature and algorithm are required.
       tags:
         - Sign Ins
       operationId: attemptSignInFactorOne
@@ -1507,7 +1519,7 @@ paths:
 
                     Can be one of the following `email_code`, `email_link`, `password`, `phone_code`,
                     `web3_metamask_signature`, `web3_base_signature`, `web3_coinbase_wallet_signature`, `web3_okx_wallet_signature`,
-                    `reset_password_phone_code`, `reset_password_email_code`, `passkey`, `google_one_tap`
+                    `reset_password_phone_code`, `reset_password_email_code`, `passkey`, `trusted_device`, `google_one_tap`
                 code:
                   type: string
                   description: The code that was sent to the email. Used with the `email_code`, `phone_code`, and `email_link` strategies.
@@ -1518,7 +1530,7 @@ paths:
                   nullable: true
                 signature:
                   type: string
-                  description: Used with the `web3_metamask_signature`, `web3_base_signature`, `web3_coinbase_wallet_signature` and `web3_okx_wallet_signature` strategies.
+                  description: Used with the `web3_metamask_signature`, `web3_base_signature`, `web3_coinbase_wallet_signature`, `web3_okx_wallet_signature`, and `trusted_device` strategies.
                   nullable: true
                 token:
                   type: string
@@ -1531,6 +1543,20 @@ paths:
                 public_key_credential:
                   type: string
                   description: Used with the `passkey` strategy.
+                  nullable: true
+                trusted_device_id:
+                  type: string
+                  description: Used with the `trusted_device` strategy.
+                  nullable: true
+                client_data:
+                  type: string
+                  description: Canonical trusted-device challenge payload returned by prepare.
+                  nullable: true
+                algorithm:
+                  type: string
+                  enum:
+                    - ES256
+                  description: Signature algorithm used with the `trusted_device` strategy.
                   nullable: true
               required:
                 - strategy
@@ -10292,6 +10318,7 @@ components:
             - reset_password_email_code
             - reset_password_phone_code
             - passkey
+            - trusted_device
             - google_one_tap
         safe_identifier:
           type: string
@@ -10306,6 +10333,8 @@ components:
         web3_wallet_id:
           type: string
         passkey_id:
+          type: string
+        trusted_device_id:
           type: string
         primary:
           type: boolean
@@ -10375,6 +10404,67 @@ components:
         attempts:
           type: integer
           nullable: true
+      required:
+        - status
+        - strategy
+        - expire_at
+    Stubs.Verification.TrustedDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - verification_trusted_device
+        status:
+          type: string
+          enum:
+            - unverified
+            - verified
+            - failed
+            - expired
+        strategy:
+          type: string
+          enum:
+            - trusted_device
+        attempts:
+          type: integer
+          nullable: true
+        expire_at:
+          type: integer
+          nullable: true
+        trusted_device_challenge:
+          type: object
+          nullable: true
+          additionalProperties: false
+          properties:
+            object:
+              type: string
+              enum:
+                - trusted_device_challenge
+            challenge:
+              type: string
+            challenge_id:
+              type: string
+            trusted_device_id:
+              type: string
+            client_data:
+              type: string
+            expires_at:
+              type: integer
+              format: int64
+            algorithm:
+              type: string
+              enum:
+                - ES256
+          required:
+            - object
+            - challenge
+            - challenge_id
+            - trusted_device_id
+            - client_data
+            - expires_at
+            - algorithm
       required:
         - status
         - strategy
@@ -10512,6 +10602,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Ticket'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.GoogleOneTap'
         second_factor_verification:
           type: object
@@ -10891,6 +10982,28 @@ components:
         - after_leave_organization_url
         - logo_link_url
         - customization
+    Client.NativeSettings:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - native_settings
+        api_enabled:
+          type: boolean
+        trusted_device_sign_in_enabled:
+          type: boolean
+        trusted_device_enrollment_prompt_after_sign_in_enabled:
+          type: boolean
+        trusted_device_enrollment_prompt_after_sign_up_enabled:
+          type: boolean
+      required:
+        - object
+        - api_enabled
+        - trusted_device_sign_in_enabled
+        - trusted_device_enrollment_prompt_after_sign_in_enabled
+        - trusted_device_enrollment_prompt_after_sign_up_enabled
     Client.AuthConfig:
       type: object
       additionalProperties: false
@@ -10977,6 +11090,8 @@ components:
           nullable: true
         reverification:
           type: boolean
+        native_settings:
+          $ref: '#/components/schemas/Client.NativeSettings'
       required:
         - object
         - id
@@ -10997,6 +11112,7 @@ components:
         - url_based_session_syncing
         - claimed_at
         - reverification
+        - native_settings
     Image:
       type: object
       properties:
@@ -11978,6 +12094,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Ticket'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.GoogleOneTap'
         second_factor_verification:
           type: object
@@ -12267,6 +12384,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Password'
             - $ref: '#/components/schemas/Stubs.Verification.OTP'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
         second_factor_verification:
           type: object

--- a/fapi/2026-05-12.yml
+++ b/fapi/2026-05-12.yml
@@ -77,6 +77,8 @@ tags:
     description: Used to interact with the web3 wallets of the logged in user.
   - name: Passkeys
     description: Used to interact with the passkeys of the logged in user.
+  - name: Trusted Devices
+    description: Used to interact with native trusted-device credentials of the logged in user.
   - name: External Accounts
     description: Used to interact with the external accounts of the current user.
   - name: TOTP
@@ -1227,6 +1229,8 @@ paths:
 
         If the strategy equals `passkey` then no identifier is provided.
 
+        If the strategy equals `trusted_device` then trusted_device_id is required.
+
         If the strategy equals `google_one_tap` then token is required.
       tags:
         - Sign Ins
@@ -1248,7 +1252,7 @@ paths:
                   type: string
                   description: |-
                     Strategy used to sign in.
-                    Can be one of `phone_code`, `email_code`, `ticket`, `web3_[provider]_signature` `reset_password_code`, `reset_password_phone_code`, `email_link`, `oauth_[provider]`, `oauth_token_[provider]`, `saml`, `password`, `passkey`, `google_one_tap`
+                    Can be one of `phone_code`, `email_code`, `ticket`, `web3_[provider]_signature` `reset_password_code`, `reset_password_phone_code`, `email_link`, `oauth_[provider]`, `oauth_token_[provider]`, `saml`, `password`, `passkey`, `trusted_device`, `google_one_tap`
                   nullable: true
                 identifier:
                   type: string
@@ -1290,6 +1294,10 @@ paths:
                 proof_token:
                   type: string
                   description: Proof token produced by the Clerk Protect SDK.
+                  nullable: true
+                trusted_device_id:
+                  type: string
+                  description: Used with the `trusted_device` strategy.
                   nullable: true
       responses:
         '200':
@@ -1383,6 +1391,7 @@ paths:
         If the strategy equals phone_code then this request will send an SMS with an OTP code.
         If the strategy equals oauth_[provider] then this request generate a URL that the User needs to visit in order to authenticate.
         If the strategy equals passkey then this request will begin the passkey registration flow.
+        If the strategy equals trusted_device then this request will issue a trusted-device sign-in challenge.
 
         Parameter rules:
         If the strategy equals `oauth_[provider]` then a redirect_url is required, and an action_complete_redirect_url is optional.
@@ -1415,7 +1424,7 @@ paths:
                     Can be one of the following `email_code`, `email_link`,
                     `phone_code`, `web3_metamask_signature`, `web3_base_signature`, `web3_coinbase_wallet_signature`,
                     `web3_okx_wallet_signature`, `reset_password_phone_code`, `reset_password_email_code`,
-                    `oauth_[provider]`, `saml`, `passkey`, `enterprise_sso`
+                    `oauth_[provider]`, `saml`, `passkey`, `trusted_device`, `enterprise_sso`
                 email_address_id:
                   type: string
                   description: Used with the `email_code`, `reset_password_email_code` and `email_link` strategies.
@@ -1435,6 +1444,10 @@ paths:
                 passkey_id:
                   type: string
                   description: Used with the `passkey` strategy.
+                  nullable: true
+                trusted_device_id:
+                  type: string
+                  description: Used with the `trusted_device` strategy.
                   nullable: true
                 redirect_url:
                   type: string
@@ -1479,6 +1492,7 @@ paths:
         Parameter rules:
         If the strategy equals `email_code` or `phone_code` then a code is required.
         If the strategy equals `password` then a password is required.
+        If the strategy equals `trusted_device` then trusted_device_id, client_data, signature and algorithm are required.
       tags:
         - Sign Ins
       operationId: attemptSignInFactorOne
@@ -1507,7 +1521,7 @@ paths:
 
                     Can be one of the following `email_code`, `email_link`, `password`, `phone_code`,
                     `web3_metamask_signature`, `web3_base_signature`, `web3_coinbase_wallet_signature`, `web3_okx_wallet_signature`,
-                    `reset_password_phone_code`, `reset_password_email_code`, `passkey`, `google_one_tap`
+                    `reset_password_phone_code`, `reset_password_email_code`, `passkey`, `trusted_device`, `google_one_tap`
                 code:
                   type: string
                   description: The code that was sent to the email. Used with the `email_code`, `phone_code`, and `email_link` strategies.
@@ -1518,7 +1532,7 @@ paths:
                   nullable: true
                 signature:
                   type: string
-                  description: Used with the `web3_metamask_signature`, `web3_base_signature`, `web3_coinbase_wallet_signature` and `web3_okx_wallet_signature` strategies.
+                  description: Used with the `web3_metamask_signature`, `web3_base_signature`, `web3_coinbase_wallet_signature`, `web3_okx_wallet_signature`, and `trusted_device` strategies.
                   nullable: true
                 token:
                   type: string
@@ -1531,6 +1545,20 @@ paths:
                 public_key_credential:
                   type: string
                   description: Used with the `passkey` strategy.
+                  nullable: true
+                trusted_device_id:
+                  type: string
+                  description: Used with the `trusted_device` strategy.
+                  nullable: true
+                client_data:
+                  type: string
+                  description: Canonical trusted-device challenge payload returned by prepare.
+                  nullable: true
+                algorithm:
+                  type: string
+                  enum:
+                    - ES256
+                  description: Signature algorithm used with the `trusted_device` strategy.
                   nullable: true
               required:
                 - strategy
@@ -2154,6 +2182,40 @@ paths:
           $ref: '#/components/responses/ClerkErrors'
   /v1/client/hosted_auth: {}
   /v1/client/hosted_auth/complete: {}
+  /v1/client/trusted_devices/validate:
+    post:
+      summary: Validate Trusted Device Sign-In Credential
+      description: Validates that a local trusted-device credential can be used by the current native client.
+      operationId: validateTrustedDevice
+      tags:
+        - Trusted Devices
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                trusted_device_id:
+                  type: string
+                  description: The trusted-device credential ID stored by the native SDK.
+              required:
+                - trusted_device_id
+      responses:
+        '200':
+          description: Returns whether the trusted-device credential is valid for the current client.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Client.ClientWrappedTrustedDeviceValidation'
+        '400':
+          $ref: '#/components/responses/ClerkErrors'
+        '401':
+          $ref: '#/components/responses/ClerkErrors'
+        '403':
+          $ref: '#/components/responses/ClerkErrors'
+        '422':
+          $ref: '#/components/responses/ClerkErrors'
   /v1/agents/tasks:
     get:
       x-speakeasy-group: agentTasks
@@ -4596,6 +4658,165 @@ paths:
         '404':
           $ref: '#/components/responses/ClerkErrors'
         '422':
+          $ref: '#/components/responses/ClerkErrors'
+  /v1/me/trusted_devices:
+    get:
+      summary: List Trusted Devices
+      description: Retrieve active trusted-device credentials associated with the current user.
+      operationId: listTrustedDevices
+      tags:
+        - Trusted Devices
+      responses:
+        '200':
+          description: Returns the current user's trusted-device credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Client.ClientWrappedTrustedDevices'
+        '401':
+          $ref: '#/components/responses/ClerkErrors'
+        '403':
+          $ref: '#/components/responses/ClerkErrors'
+  /v1/me/trusted_devices/prepare:
+    post:
+      summary: Prepare Trusted Device Enrollment
+      description: Issues a one-time challenge for enrolling a native trusted-device credential.
+      operationId: prepareTrustedDevice
+      tags:
+        - Trusted Devices
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                platform:
+                  type: string
+                  enum:
+                    - ios
+                    - android
+                app_identifier:
+                  type: string
+                  description: Bundle identifier or package name for the native application.
+                name:
+                  type: string
+                  nullable: true
+                  description: Optional user-facing device name.
+                algorithm:
+                  type: string
+                  enum:
+                    - ES256
+                public_key_jwk:
+                  type: string
+                  description: Canonical public JWK for the device-bound P-256 key.
+              required:
+                - platform
+                - app_identifier
+                - algorithm
+                - public_key_jwk
+      responses:
+        '200':
+          description: Returns the enrollment challenge that must be signed by the native private key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Client.ClientWrappedTrustedDeviceChallenge'
+        '400':
+          $ref: '#/components/responses/ClerkErrors'
+        '401':
+          $ref: '#/components/responses/ClerkErrors'
+        '403':
+          $ref: '#/components/responses/ClerkErrors'
+        '422':
+          $ref: '#/components/responses/ClerkErrors'
+  /v1/me/trusted_devices/attempt:
+    post:
+      summary: Attempt Trusted Device Enrollment
+      description: Verifies a signed enrollment challenge and creates a trusted-device credential.
+      operationId: attemptTrustedDevice
+      tags:
+        - Trusted Devices
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                platform:
+                  type: string
+                  enum:
+                    - ios
+                    - android
+                app_identifier:
+                  type: string
+                  description: Bundle identifier or package name for the native application.
+                name:
+                  type: string
+                  nullable: true
+                  description: Optional user-facing device name.
+                algorithm:
+                  type: string
+                  enum:
+                    - ES256
+                public_key_jwk:
+                  type: string
+                  description: Canonical public JWK for the device-bound P-256 key.
+                client_data:
+                  type: string
+                  description: Canonical JSON challenge payload returned from prepare.
+                signature:
+                  type: string
+                  description: Base64url raw ECDSA P-256 signature over `client_data`.
+              required:
+                - platform
+                - app_identifier
+                - algorithm
+                - public_key_jwk
+                - client_data
+                - signature
+      responses:
+        '200':
+          description: Returns the created trusted-device credential.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Client.ClientWrappedTrustedDevice'
+        '400':
+          $ref: '#/components/responses/ClerkErrors'
+        '401':
+          $ref: '#/components/responses/ClerkErrors'
+        '403':
+          $ref: '#/components/responses/ClerkErrors'
+        '422':
+          $ref: '#/components/responses/ClerkErrors'
+  /v1/me/trusted_devices/{trusted_device_id}:
+    delete:
+      summary: Revoke Trusted Device
+      description: Revokes a trusted-device credential so it can no longer authenticate.
+      operationId: revokeTrustedDevice
+      tags:
+        - Trusted Devices
+      parameters:
+        - in: path
+          required: true
+          name: trusted_device_id
+          schema:
+            type: string
+          description: The trusted-device credential ID.
+      responses:
+        '200':
+          description: Returns the revoked trusted-device credential.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Client.ClientWrappedTrustedDevice'
+        '401':
+          $ref: '#/components/responses/ClerkErrors'
+        '403':
+          $ref: '#/components/responses/ClerkErrors'
+        '404':
           $ref: '#/components/responses/ClerkErrors'
   /v1/me/external_accounts:
     post:
@@ -10539,6 +10760,7 @@ components:
             - reset_password_email_code
             - reset_password_phone_code
             - passkey
+            - trusted_device
             - google_one_tap
         safe_identifier:
           type: string
@@ -10553,6 +10775,8 @@ components:
         web3_wallet_id:
           type: string
         passkey_id:
+          type: string
+        trusted_device_id:
           type: string
         primary:
           type: boolean
@@ -10622,6 +10846,67 @@ components:
         attempts:
           type: integer
           nullable: true
+      required:
+        - status
+        - strategy
+        - expire_at
+    Stubs.Verification.TrustedDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - verification_trusted_device
+        status:
+          type: string
+          enum:
+            - unverified
+            - verified
+            - failed
+            - expired
+        strategy:
+          type: string
+          enum:
+            - trusted_device
+        attempts:
+          type: integer
+          nullable: true
+        expire_at:
+          type: integer
+          nullable: true
+        trusted_device_challenge:
+          type: object
+          nullable: true
+          additionalProperties: false
+          properties:
+            object:
+              type: string
+              enum:
+                - trusted_device_challenge
+            challenge:
+              type: string
+            challenge_id:
+              type: string
+            trusted_device_id:
+              type: string
+            client_data:
+              type: string
+            expires_at:
+              type: integer
+              format: int64
+            algorithm:
+              type: string
+              enum:
+                - ES256
+          required:
+            - object
+            - challenge
+            - challenge_id
+            - trusted_device_id
+            - client_data
+            - expires_at
+            - algorithm
       required:
         - status
         - strategy
@@ -10759,6 +11044,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Ticket'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.GoogleOneTap'
         second_factor_verification:
           type: object
@@ -11138,6 +11424,28 @@ components:
         - after_leave_organization_url
         - logo_link_url
         - customization
+    Client.NativeSettings:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - native_settings
+        api_enabled:
+          type: boolean
+        trusted_device_sign_in_enabled:
+          type: boolean
+        trusted_device_enrollment_prompt_after_sign_in_enabled:
+          type: boolean
+        trusted_device_enrollment_prompt_after_sign_up_enabled:
+          type: boolean
+      required:
+        - object
+        - api_enabled
+        - trusted_device_sign_in_enabled
+        - trusted_device_enrollment_prompt_after_sign_in_enabled
+        - trusted_device_enrollment_prompt_after_sign_up_enabled
     Client.AuthConfig:
       type: object
       additionalProperties: false
@@ -11224,6 +11532,8 @@ components:
           nullable: true
         reverification:
           type: boolean
+        native_settings:
+          $ref: '#/components/schemas/Client.NativeSettings'
       required:
         - object
         - id
@@ -11244,6 +11554,7 @@ components:
         - url_based_session_syncing
         - claimed_at
         - reverification
+        - native_settings
     Image:
       type: object
       properties:
@@ -12225,6 +12536,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Ticket'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.GoogleOneTap'
         second_factor_verification:
           type: object
@@ -12420,6 +12732,36 @@ components:
       required:
         - response
         - client
+    Client.TrustedDeviceValidation:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - trusted_device_validation
+        valid:
+          type: boolean
+      required:
+        - object
+        - valid
+    Client.ClientWrappedTrustedDeviceValidation:
+      type: object
+      additionalProperties: false
+      properties:
+        response:
+          type: object
+          nullable: false
+          allOf:
+            - $ref: '#/components/schemas/Client.TrustedDeviceValidation'
+        client:
+          type: object
+          nullable: false
+          allOf:
+            - $ref: '#/components/schemas/Client.Client-2'
+      required:
+        - response
+        - client
     Client.ClientWrappedSession:
       type: object
       additionalProperties: false
@@ -12514,6 +12856,7 @@ components:
             - $ref: '#/components/schemas/Stubs.Verification.Password'
             - $ref: '#/components/schemas/Stubs.Verification.OTP'
             - $ref: '#/components/schemas/Stubs.Verification.Passkey'
+            - $ref: '#/components/schemas/Stubs.Verification.TrustedDevice'
             - $ref: '#/components/schemas/Stubs.Verification.SAML'
         second_factor_verification:
           type: object
@@ -12968,6 +13311,145 @@ components:
           nullable: false
           allOf:
             - $ref: '#/components/schemas/Client.Passkey'
+        client:
+          type: object
+          nullable: false
+          allOf:
+            - $ref: '#/components/schemas/Client.Client-2'
+      required:
+        - response
+        - client
+    Client.TrustedDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        object:
+          type: string
+          enum:
+            - trusted_device
+        platform:
+          type: string
+          enum:
+            - ios
+            - android
+        app_identifier:
+          type: string
+          description: Bundle identifier or package name for the native application that owns the credential.
+        name:
+          type: string
+          nullable: true
+          description: Optional user-facing device name supplied by the SDK.
+        algorithm:
+          type: string
+          enum:
+            - ES256
+        status:
+          type: string
+          enum:
+            - active
+            - revoked
+        created_at:
+          type: integer
+          format: int64
+        updated_at:
+          type: integer
+          format: int64
+        last_used_at:
+          type: integer
+          format: int64
+          nullable: true
+        revoked_at:
+          type: integer
+          format: int64
+          nullable: true
+      required:
+        - id
+        - object
+        - platform
+        - app_identifier
+        - name
+        - algorithm
+        - status
+        - created_at
+        - updated_at
+        - last_used_at
+        - revoked_at
+    Client.ClientWrappedTrustedDevices:
+      type: object
+      additionalProperties: false
+      properties:
+        response:
+          type: array
+          items:
+            $ref: '#/components/schemas/Client.TrustedDevice'
+        client:
+          type: object
+          nullable: false
+          allOf:
+            - $ref: '#/components/schemas/Client.Client-2'
+      required:
+        - response
+        - client
+    Client.TrustedDeviceChallenge:
+      type: object
+      additionalProperties: false
+      properties:
+        object:
+          type: string
+          enum:
+            - trusted_device_challenge
+        challenge:
+          type: string
+        challenge_id:
+          type: string
+        trusted_device_id:
+          type: string
+          description: Present for sign-in challenges and omitted for enrollment challenges.
+        client_data:
+          type: string
+          description: Canonical JSON challenge payload that the native SDK must sign.
+        expires_at:
+          type: integer
+          format: int64
+        algorithm:
+          type: string
+          enum:
+            - ES256
+      required:
+        - object
+        - challenge
+        - challenge_id
+        - client_data
+        - expires_at
+        - algorithm
+    Client.ClientWrappedTrustedDeviceChallenge:
+      type: object
+      additionalProperties: false
+      properties:
+        response:
+          type: object
+          nullable: false
+          allOf:
+            - $ref: '#/components/schemas/Client.TrustedDeviceChallenge'
+        client:
+          type: object
+          nullable: false
+          allOf:
+            - $ref: '#/components/schemas/Client.Client-2'
+      required:
+        - response
+        - client
+    Client.ClientWrappedTrustedDevice:
+      type: object
+      additionalProperties: false
+      properties:
+        response:
+          type: object
+          nullable: false
+          allOf:
+            - $ref: '#/components/schemas/Client.TrustedDevice'
         client:
           type: object
           nullable: false
@@ -16059,6 +16541,7 @@ x-tagGroups:
       - Phone Numbers
       - Web3 Wallets
       - Passkeys
+      - Trusted Devices
       - External Accounts
       - TOTP
       - Backup Codes

--- a/webhooks/2025-04-15.yml
+++ b/webhooks/2025-04-15.yml
@@ -1534,24 +1534,6 @@ x-webhooks:
             examples:
               default:
                 $ref: '#/components/examples/SubscriptionItemActiveExample'
-  subscriptionItem.created:
-    post:
-      description: Subscription Item Created
-      operationId: subscriptionItem.created
-      requestBody:
-        content:
-          application/json:
-            schema:
-              allOf:
-                - $ref: '#/components/schemas/WebhookEventPayload'
-                - properties:
-                    data:
-                      $ref: '#/components/schemas/BillingSubscriptionItemEventPayload'
-                  required:
-                    - data
-            examples:
-              default:
-                $ref: '#/components/examples/SubscriptionItemCreatedExample'
   subscriptionItem.canceled:
     post:
       description: Subscription Item Canceled
@@ -5294,47 +5276,6 @@ components:
                     currency: USD
           seats:
             quantity: 5
-          payer:
-            object: commerce_payer
-            id: cpayer_2g7np7Hrk0SN6kj5EDMLDaKNL0S
-            user_id: user_34D368EufHwugfYh4yyGNEheM0S
-            first_name: Test
-            last_name: User
-            email: test@example.com
-            organization_id: ''
-            organization_name: ''
-            image_url: https://img.clerk.com/xxxxxx
-            created_at: 1716883200000
-            updated_at: 1716883200000
-          subscription_id: csub_2g7np7Hrk0SN6kj5EDMLDaKNL0S
-    SubscriptionItemCreatedExample:
-      value:
-        event_attributes:
-          http_request:
-            client_ip: 192.168.1.100
-            user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36
-        object: event
-        type: subscriptionItem.created
-        instance_id: ins_2g7np7Hrk0SN6kj5EDMLDaKNL0S
-        timestamp: 1716883200
-        data:
-          object: subscription_item
-          id: csub_item_2g7np7Hrk0SN6kj5EDMLDaKNL0S
-          status: upcoming
-          is_free_trial: false
-          created_at: 1716883200000
-          updated_at: 1716883200000
-          period_start: 1716883200000
-          period_end: 1719561600000
-          interval: month
-          plan_id: cplan_2g7np7Hrk0SN6kj5EDMLDaKNL0S
-          plan:
-            id: cplan_2g7np7Hrk0SN6kj5EDMLDaKNL0S
-            slug: pro-plan
-            name: Pro Plan
-            is_recurring: true
-            amount: 2000
-            currency: USD
           payer:
             object: commerce_payer
             id: cpayer_2g7np7Hrk0SN6kj5EDMLDaKNL0S


### PR DESCRIPTION
This PR publishes a generated snapshot of the production OpenAPI specifications used by Clerk's public API reference.

## User password removal

Adds the Backend API operation for removing a user's password:

```http
POST /v1/users/{user_id}/remove_password
```

The operation:

- Does not require the user's current password.
- Allows password removal even when the user has no alternate sign-in method configured.
- Leaves existing sessions active by default.
- Accepts the optional `sign_out_of_other_sessions` field to revoke the user's active sessions.
- Returns the updated User resource.

Public SDK follow-ups:

- [JavaScript SDK support](https://github.com/clerk/javascript/pull/9326)
- [Go SDK support](https://github.com/clerk/clerk-sdk-go/pull/586)

## Other generated production changes

Because this repository publishes bundled production snapshots, this PR also includes:

- Support for replacing unverified email and phone identifiers.
- Trusted-device operations and schemas across the Backend and Frontend APIs.
- Removal of the unused `subscriptionItem.created` webhook specification entry.

## Verification

- Confirmed the password-removal operation is present in every supported Backend API version.
- Confirmed the generated API reference renders the endpoint behavior, optional `sign_out_of_other_sessions` field, response codes, and cURL example correctly.
